### PR TITLE
Update to bon 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-interface"]
 authors = ["Adrian Papari <junkdog@angelhill.net>"]
 
 [dependencies]
-bon = "1.2.1"
+bon = { git = "https://github.com/elastio/bon" }
 colorsys = "0.6.7"
 ratatui = "0.28.0"
 simple-easing = "1.0.1"

--- a/src/fx/shader_fn.rs
+++ b/src/fx/shader_fn.rs
@@ -15,7 +15,10 @@ pub struct ShaderFn<S: Clone> {
     original_state: Option<S>,
     name: &'static str,
     code: ShaderFnSignature<S>,
+
+    #[builder(into)]
     timer: EffectTimer,
+
     cell_filter: Option<CellFilter>,
     area: Option<Rect>,
 }
@@ -177,4 +180,3 @@ impl<S: Clone + 'static> Shader for ShaderFn<S> {
         self.state = self.original_state.as_ref().unwrap().clone();
     }
 }
-

--- a/src/widget/effect_timeline.rs
+++ b/src/widget/effect_timeline.rs
@@ -1,4 +1,4 @@
-use bon::{bon, builder};
+use bon::bon;
 use crate::widget::effect_span::effect_span_tree;
 use crate::widget::{CellFilterRegistry, ColorRegistry, EffectSpan};
 use crate::{CellFilter, Effect, HslConvertable, Shader};


### PR DESCRIPTION
Hi! I'm the maintainer of the [`bon` crate](https://github.com/elastio/bon). I've created a 2.0 release with some breaking changes. While there aren't too many repos using `bon`, I'm assisting with the upgrade myself.

There is the link to the [Reddit post](https://www.reddit.com/r/rust/comments/1f1uzkw/bon_builder_generator_20_release/) and the [blog post](https://elastio.github.io/bon/blog/bon-builder-generator-v2-release) itself.

The main breaking change that requires a migration is that there will no longer be automatic `Into` conversions (https://github.com/elastio/bon/issues/15#issuecomment-2297202745). It means there won't be automatic `impl Into<String>` in setters. If you want to enable `impl Into` for all `String` types, you need to use `#[builder(on(String, into))]` at the top level or add `#[builder(into)]` at the member level.

Also, any feedback on this change would be appreciated!

---

I see there are a lot of usages of `#[builder]` in `pub` items. It means a lot of setters now accept `impl Into<_>`. Do you think it makes sense to review all the setters and remove `impl Into<_>` from them (which would be a breaking change for the crate), or should we just enable `impl Into` everywhere where `bon` v1 enabled it automatically?