### PR TITLE
Add WebAssembly support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +253,16 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -518,6 +534,7 @@ dependencies = [
  "crossterm",
  "ratatui",
  "simple-easing",
+ "web-time",
 ]
 
 [[package]]
@@ -565,6 +582,73 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,14 @@ bon = "3.3.2"
 colorsys = "0.6.7"
 ratatui = { version = "0.29", default-features = false }
 simple-easing = "1.0.1"
+web-time = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 crossterm = "0.28.1"
 
 [features]
 default = ["crossterm"]
+web-time = ["dep:web-time"]
 std-duration = []
 sendable = []
 crossterm = ["ratatui/crossterm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,17 @@ exclude = ["images/*.gif", "docs/assets/*.gif", ".*"]
 [dependencies]
 bon = "3.3.2"
 colorsys = "0.6.7"
-ratatui = "0.29.0"
+ratatui = { version = "0.29", default-features = false }
 simple-easing = "1.0.1"
 
 [dev-dependencies]
 crossterm = "0.28.1"
 
 [features]
+default = ["crossterm"]
 std-duration = []
 sendable = []
+crossterm = ["ratatui/crossterm"]
 
 [[example]]
 name = "minimal"

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -136,15 +136,32 @@ pub mod duration {
         }
     }
 
+
+    #[cfg(not(feature = "web-time"))]
     impl From<std::time::Duration> for Duration {
         fn from(d: std::time::Duration) -> Self {
             Self { milliseconds: d.as_millis() as u32 }
         }
     }
 
+    #[cfg(feature = "web-time")]
+    impl From<web_time::Duration> for Duration {
+        fn from(d: web_time::Duration) -> Self {
+            Self { milliseconds: d.as_millis() as u32 }
+        }
+    }
+
+    #[cfg(not(feature = "web-time"))]
     impl From<Duration> for std::time::Duration {
         fn from(d: Duration) -> Self {
             std::time::Duration::from_millis(d.milliseconds as u64)
+        }
+    }
+
+    #[cfg(feature = "web-time")]
+    impl From<Duration> for web_time::Duration {
+        fn from(d: Duration) -> Self {
+            web_time::Duration::from_millis(d.milliseconds as u64)
         }
     }
 

--- a/src/simple_rng.rs
+++ b/src/simple_rng.rs
@@ -1,5 +1,8 @@
 use std::ops::Range;
+#[cfg(not(feature = "web-time"))]
 use std::time::SystemTime;
+#[cfg(feature = "web-time")]
+use web_time::SystemTime;
 
 /// A simple pseudo-random number generator using the Linear Congruential Generator algorithm.
 ///

--- a/src/simple_rng.rs
+++ b/src/simple_rng.rs
@@ -61,7 +61,8 @@ impl SimpleRng {
 
     fn gen_usize(&mut self) -> usize {
         let mut g = || self.gen() as usize;
-        g() << 32 | g()
+        let v = (g() as u64) << 32 | g() as u64;
+        v as usize
     }
 }
 


### PR DESCRIPTION
As of now `tachyonfx` does not support compiling for `wasm32-unknown-unknown` due to the following issues:

- Dependency on Ratatui's crossterm backend: which obviously does not support compiling for web applications.
- Dependency on `std::time` which is not supported in WASM

To fix those, I added two new feature flags for disabling `crossterm` and depending on [`web_time`](https://docs.rs/web-time) crate.

Also, there was a platform-dependent panic in `gen_usize` function (which is now fixed in an ugly way >.<).

In the end, `tachyonfx` now supports WASM by importing as:

```toml
tachyonfx = { version = "*", default-features = false, features = ["web-time"] }
```

P.S. I'm now experimenting with rendering shaders on web via [ratzilla](https://github.com/orhun/ratzilla) :)
