### PR TITLE
ratatui 0.30.0 alpha preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
-ratatui = { version = "0.29.0", default-features = false }
+ratatui = { version = "0.30.0-alpha.5", default-features = false }
 compact_str = { version = "0.9.0", default-features = false }
 crossterm = "0.29.0"
 tachyonfx = { path = "." }
@@ -52,7 +52,7 @@ criterion = "0.7.0"
 
 [features]
 default = ["std", "crossterm", "dsl"]
-std = ["bon/std", "compact_str/std", "thiserror/std"] # "ratatui/std" once 0.30 is released
+std = ["bon/std", "compact_str/std", "thiserror/std", "ratatui/std"]
 crossterm = ["std", "ratatui/crossterm"]
 dsl = ["dep:anpa"]
 sendable = []

--- a/src/dsl/completions/dsl_type.rs
+++ b/src/dsl/completions/dsl_type.rs
@@ -705,7 +705,7 @@ impl DslType for Flex {
     const TYPE_NAME: &'static str = "Flex";
 
     fn constants() -> &'static [&'static str] {
-        &["Legacy", "Start", "End", "Center", "SpaceBetween", "SpaceAround"]
+        &["Legacy", "Start", "End", "Center", "SpaceBetween", "SpaceAround", "SpaceEvenly"]
     }
 
     fn constructors() -> &'static [CallableItem] {

--- a/src/dsl/dsl_format.rs
+++ b/src/dsl/dsl_format.rs
@@ -297,6 +297,7 @@ impl DslFormat for Flex {
             Flex::Center => "Flex::Center",
             Flex::SpaceBetween => "Flex::SpaceBetween",
             Flex::SpaceAround => "Flex::SpaceAround",
+            Flex::SpaceEvenly => "Flex::SpaceEvenly",
         }
         .to_compact_string()
     }

--- a/src/dsl/expr_promotion.rs
+++ b/src/dsl/expr_promotion.rs
@@ -109,6 +109,7 @@ fn flex(text: &str) -> Option<Value> {
         "Center" => Flex::Center,
         "SpaceBetween" => Flex::SpaceBetween,
         "SpaceAround" => Flex::SpaceAround,
+        "SpaceEvenly" => Flex::SpaceEvenly,
         _ => None?,
     }))
 }


### PR DESCRIPTION
this MR is just a placeholder until ratatui 0.30.0 releases

to preview tachyonfx with ratatui 0.30 alpha/beta releases:

```toml
tachyonfx = { git = "https://github.com/junkdog/tachyonfx", branch = "ratatui-0.30-preview", default-features = false }
```