### PR TITLE
Fix: replace unstable is_multiple_of with stable modulo check

### DIFF
--- a/src/pattern/checkerboard.rs
+++ b/src/pattern/checkerboard.rs
@@ -47,7 +47,7 @@ impl CheckerboardPattern {
     fn is_white_cell(&self, x: u16, y: u16) -> bool {
         let cell_x = x / self.cell_size;
         let cell_y = y / self.cell_size;
-        (cell_x + cell_y).is_multiple_of(2)
+        ((cell_x + cell_y) % 2) == 0
     }
 }
 


### PR DESCRIPTION
The `is_white_cell(..)` function used the unstable `.is_multiple_of()` method, which caused issues on stable Rust.
This PR replaces it with a simple modulus check.

### Verification
- `cargo build` ✅  
- `cargo test` ✅  
- `cargo clippy` ✅  