### PR TITLE
feat: ambient (never-completing) effects and a noise module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "organic-effects"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "tachyonfx",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/effect-showcase",
     "examples/tweens",
     "examples/effect-registry",
+    "examples/organic-effects",
 ]
 
 [package]

--- a/examples/organic-effects/Cargo.toml
+++ b/examples/organic-effects/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "organic-effects"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+tachyonfx = { workspace = true }
+ratatui = { workspace = true, features = ["crossterm"] }
+crossterm = { workspace = true }

--- a/examples/organic-effects/src/main.rs
+++ b/examples/organic-effects/src/main.rs
@@ -1,0 +1,457 @@
+//! Ambient, noise-driven effects for tachyonfx.
+//!
+//! tachyonfx's built-in effects are mostly *transitions*: they run once and
+//! finish. This demo covers the other case — effects meant to sit under a UI
+//! indefinitely, giving it a little life without demanding attention.
+//!
+//! Each effect is compiled from its DSL string rather than constructed in Rust,
+//! so what you see on screen is exactly what a user could write in a config
+//! file, with no registration of its own.
+//!
+//! Run with `cargo run -p organic-effects`.
+
+use std::{
+    io,
+    time::{Duration as StdDuration, Instant},
+};
+
+use ratatui::{
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
+    prelude::*,
+    widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap},
+};
+use tachyonfx::{Duration, Effect, EffectRenderer, dsl::EffectDsl};
+
+/// Starting frame rate, adjustable at runtime with `+` and `-`.
+///
+/// Nothing here is limited by rendering: the loop waits for a key with a
+/// timeout, and that timeout sets the pace. Some cap is needed or the loop
+/// spins at 100% CPU redrawing as fast as it can — and since an ambient effect
+/// never finishes, that cost would be paid for as long as the UI is open.
+/// 30fps is a starting point, not a ceiling.
+const DEFAULT_FPS: u32 = 30;
+const FPS_RANGE: core::ops::RangeInclusive<u32> = 5..=240;
+
+fn frame_budget(fps: u32) -> StdDuration {
+    StdDuration::from_micros(1_000_000 / u64::from(fps))
+}
+
+struct Demo {
+    name: &'static str,
+    kind: Kind,
+    blurb: &'static str,
+    dsl: &'static str,
+}
+
+enum Kind {
+    /// Sets an absolute colour, so it fills blank cells and leaves text legible.
+    Painting,
+    /// Adjusts the colour a cell already has, so it acts on text.
+    Modulating,
+}
+
+impl Kind {
+    fn label(&self) -> &'static str {
+        match self {
+            Kind::Painting => "painting · targets blank cells",
+            Kind::Modulating => "modulating · targets glyphs",
+        }
+    }
+}
+
+const DEMOS: &[Demo] = &[
+    Demo {
+        name: "noise_field",
+        kind: Kind::Painting,
+        blurb: "A drifting fractal-noise field. The workhorse ambient background: \
+                unlike a sine-driven one it never visibly repeats.",
+        dsl: "fx::noise_field(Color::Rgb(10, 12, 30), Color::Rgb(110, 60, 160), 0.2, 1.2, 3)",
+    },
+    Demo {
+        name: "color_wave",
+        kind: Kind::Painting,
+        blurb: "A three-stop gradient sweeping sideways. Periodic and directional, \
+                so it reads as a deliberate sweep rather than drift.",
+        dsl: "fx::color_wave(Color::Rgb(40, 20, 70), Color::Rgb(20, 70, 80), \
+              Color::Rgb(90, 35, 55), 1.2, 0.06)",
+    },
+    Demo {
+        name: "glow",
+        kind: Kind::Painting,
+        blurb: "A radial bloom that breathes. Corrected for cell aspect ratio, \
+                so it is round rather than a vertical ellipse.",
+        dsl: "fx::glow(Color::Rgb(70, 90, 140), 22.0, 2.0, 3.0)",
+    },
+    Demo {
+        name: "breathe",
+        kind: Kind::Modulating,
+        blurb: "A slow brightness swell. Asymmetric on purpose — a slow rise and \
+                a quicker fall reads as breathing, where a sine reads as a machine.",
+        dsl: "fx::breathe(0.55, 3.0)",
+    },
+    Demo {
+        name: "flicker",
+        kind: Kind::Modulating,
+        blurb: "Stochastic per-column flicker, for a phosphor-tube feel. Each \
+                column has its own path, so a line never pulses in unison.",
+        dsl: "fx::flicker(0.45, 3.0)",
+    },
+    Demo {
+        name: "shimmer",
+        kind: Kind::Modulating,
+        blurb: "A smooth highlight sliding across the text. Where flicker is \
+                electrical noise, this is a moving gradient.",
+        dsl: "fx::shimmer(0.7, 0.15, 0.8)",
+    },
+    Demo {
+        name: "drift",
+        kind: Kind::Modulating,
+        blurb: "A slow noise-driven wander of the text colour, uniform across \
+                the area rather than varying per cell.",
+        dsl: "fx::drift(Color::Rgb(120, 170, 220), Color::Rgb(230, 140, 170), 1.0)",
+    },
+    Demo {
+        name: "composed",
+        kind: Kind::Painting,
+        blurb: "Painting and modulating effects run together: the filters keep \
+                them out of each other's way automatically.",
+        dsl: "fx::parallel(&[\
+                fx::noise_field(Color::Rgb(12, 16, 32), Color::Rgb(90, 50, 140), 0.22, 1.0, 3), \
+                fx::shimmer(0.4, 0.15, 0.7)])",
+    },
+];
+
+/// Rolling frame-timing stats.
+///
+/// Frame rate alone would be misleading here: the loop blocks on
+/// `event::poll(FRAME)`, so it reads ~30fps whatever the effect costs. The draw
+/// time is the number that actually reflects the effect's expense, and for an
+/// ambient effect -- which runs for as long as the UI is open -- that is the
+/// figure worth watching.
+struct Stats {
+    frames: [f32; Stats::WINDOW],
+    draws: [f32; Stats::WINDOW],
+    next: usize,
+    filled: usize,
+}
+
+impl Stats {
+    /// Two seconds at ~30fps: long enough to be steady, short enough to react
+    /// when switching effects.
+    const WINDOW: usize = 60;
+
+    fn new() -> Self {
+        Self {
+            frames: [0.0; Self::WINDOW],
+            draws: [0.0; Self::WINDOW],
+            next: 0,
+            filled: 0,
+        }
+    }
+
+    fn record(&mut self, frame: StdDuration, draw: StdDuration) {
+        self.frames[self.next] = frame.as_secs_f32();
+        self.draws[self.next] = draw.as_secs_f32();
+        self.next = (self.next + 1) % Self::WINDOW;
+        self.filled = (self.filled + 1).min(Self::WINDOW);
+    }
+
+    fn mean(values: &[f32], n: usize) -> f32 {
+        if n == 0 {
+            return 0.0;
+        }
+        values[..n].iter().sum::<f32>() / n as f32
+    }
+
+    fn fps(&self) -> f32 {
+        let mean = Self::mean(&self.frames, self.filled);
+        if mean > 0.0 { 1.0 / mean } else { 0.0 }
+    }
+
+    /// Mean milliseconds spent building and flushing a frame.
+    fn draw_ms(&self) -> f32 {
+        Self::mean(&self.draws, self.filled) * 1000.0
+    }
+
+    /// Slowest draw in the window, in milliseconds. The mean hides the spikes
+    /// that are actually felt as stutter.
+    fn peak_draw_ms(&self) -> f32 {
+        self.draws[..self.filled]
+            .iter()
+            .copied()
+            .fold(0.0, f32::max)
+            * 1000.0
+    }
+}
+
+/// Steps the target frame rate through a set of round values, so `+` and `-`
+/// make a visible difference rather than nudging it by one.
+fn step_fps(current: u32, up: bool) -> u32 {
+    const STOPS: [u32; 7] = [5, 10, 15, 30, 60, 120, 240];
+    let position = STOPS.iter().position(|&s| s == current).unwrap_or(3);
+    let next = if up {
+        (position + 1).min(STOPS.len() - 1)
+    } else {
+        position.saturating_sub(1)
+    };
+    STOPS[next].clamp(*FPS_RANGE.start(), *FPS_RANGE.end())
+}
+
+fn compile(index: usize) -> Effect {
+    // These are built-ins, so a default DSL already knows them.
+    let dsl = EffectDsl::new();
+    dsl.compiler()
+        .compile(DEMOS[index].dsl)
+        .expect("demo expressions are checked by the unit tests")
+}
+
+fn main() -> io::Result<()> {
+    let mut terminal = ratatui::init();
+    let mut index = 0usize;
+    let mut effect = compile(index);
+    let mut last = Instant::now();
+    let mut stats = Stats::new();
+    let mut target_fps = DEFAULT_FPS;
+
+    loop {
+        let delta = last.elapsed();
+        last = Instant::now();
+
+        let draw_start = Instant::now();
+        terminal.draw(|f| ui(f, index, &mut effect, delta.into(), &stats, target_fps))?;
+        let draw = draw_start.elapsed();
+        stats.record(delta, draw);
+
+        if event::poll(frame_budget(target_fps))?
+            && let Event::Key(key) = event::read()?
+            // Terminals may report releases too; without this every press
+            // would advance twice and skip an effect.
+            && key.kind == KeyEventKind::Press
+        {
+            let previous = index;
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Right | KeyCode::Char('l' | ' ') => {
+                    index = (index + 1) % DEMOS.len();
+                },
+                KeyCode::Left | KeyCode::Char('h') => {
+                    index = (index + DEMOS.len() - 1) % DEMOS.len();
+                },
+                KeyCode::Char('+' | '=') => {
+                    target_fps = step_fps(target_fps, true);
+                    stats = Stats::new();
+                },
+                KeyCode::Char('-' | '_') => {
+                    target_fps = step_fps(target_fps, false);
+                    stats = Stats::new();
+                },
+                _ => {},
+            }
+            if index != previous {
+                effect = compile(index);
+                // Otherwise the previous effect's timings linger in the window.
+                stats = Stats::new();
+            }
+        }
+    }
+
+    ratatui::restore();
+    Ok(())
+}
+
+fn ui(
+    f: &mut Frame<'_>,
+    index: usize,
+    effect: &mut Effect,
+    delta: Duration,
+    stats: &Stats,
+    target_fps: u32,
+) {
+    let demo = &DEMOS[index];
+
+    Clear.render(f.area(), f.buffer_mut());
+    Block::default()
+        .style(Style::default().bg(Color::Rgb(16, 16, 22)))
+        .render(f.area(), f.buffer_mut());
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Min(8),
+        Constraint::Length(6),
+        Constraint::Length(1),
+    ])
+    .split(f.area());
+
+    let heading = Line::from(vec![
+        Span::styled(
+            format!(" {} ", demo.name),
+            Style::default()
+                .fg(Color::Rgb(240, 240, 250))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("· {} ", demo.kind.label()),
+            Style::default().fg(Color::Rgb(130, 140, 165)),
+        ),
+        Span::styled(
+            format!("· {}/{}", index + 1, DEMOS.len()),
+            Style::default().fg(Color::Rgb(90, 100, 125)),
+        ),
+    ]);
+    f.render_widget(
+        Paragraph::new(heading).block(Block::default().borders(Borders::BOTTOM)),
+        chunks[0],
+    );
+
+    // Deliberately mixes text with generous blank space, so painting effects
+    // (which fill the blanks) and modulating ones (which act on the glyphs) are
+    // both visible on the same screen.
+    let body = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(demo.blurb).style(Style::default().fg(Color::Rgb(205, 210, 230))),
+        Line::from(""),
+        Line::from(""),
+        Line::from("      The quick brown fox jumps over the lazy dog")
+            .style(Style::default().fg(Color::Rgb(150, 190, 220))),
+        Line::from("      0123456789  ──────────  ▲ ▼ ◆ ●")
+            .style(Style::default().fg(Color::Rgb(190, 160, 210))),
+        Line::from(""),
+        Line::from(""),
+    ])
+    .wrap(Wrap { trim: true })
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Rgb(60, 66, 86)))
+            .padding(Padding::horizontal(2)),
+    );
+    f.render_widget(body, chunks[1]);
+
+    let source = Paragraph::new(demo.dsl)
+        .wrap(Wrap { trim: true })
+        .style(Style::default().fg(Color::Rgb(150, 200, 170)))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Rgb(50, 56, 72)))
+                .title(" compiled from this DSL expression ")
+                .title_style(Style::default().fg(Color::Rgb(110, 120, 145)))
+                .padding(Padding::horizontal(1)),
+        );
+    f.render_widget(source, chunks[2]);
+
+    let footer = Line::from(vec![
+        Span::styled(
+            " ←/→ effect   ·   +/- frame rate   ·   q quit",
+            Style::default().fg(Color::Rgb(90, 100, 125)),
+        ),
+        Span::styled(
+            format!(
+                "   ·   {:.0}/{target_fps} fps   ·   draw {:.2}ms (peak {:.2}ms)",
+                stats.fps(),
+                stats.draw_ms(),
+                stats.peak_draw_ms(),
+            ),
+            Style::default().fg(Color::Rgb(120, 145, 120)),
+        ),
+    ]);
+    f.render_widget(Paragraph::new(footer), chunks[3]);
+
+    // Ambient effects are applied last, over everything already rendered: the
+    // cell filters need the glyphs to be on screen to tell them from blanks.
+    f.render_effect(effect, f.area(), delta);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(v: u64) -> StdDuration {
+        StdDuration::from_millis(v)
+    }
+
+    #[test]
+    fn empty_stats_report_zero_rather_than_dividing_by_zero() {
+        let stats = Stats::new();
+        assert_eq!(stats.fps(), 0.0);
+        assert_eq!(stats.draw_ms(), 0.0);
+        assert_eq!(stats.peak_draw_ms(), 0.0);
+    }
+
+    #[test]
+    fn steady_frames_report_the_expected_rate() {
+        let mut stats = Stats::new();
+        for _ in 0..10 {
+            stats.record(ms(33), ms(1));
+        }
+        assert!(
+            (stats.fps() - 30.3).abs() < 0.5,
+            "33ms frames should read ~30fps, got {}",
+            stats.fps()
+        );
+        assert!((stats.draw_ms() - 1.0).abs() < 0.01);
+    }
+
+    /// The mean smooths away exactly the spikes that are felt as stutter, which
+    /// is why the peak is reported alongside it.
+    #[test]
+    fn peak_survives_a_window_of_fast_frames() {
+        let mut stats = Stats::new();
+        stats.record(ms(33), ms(20));
+        for _ in 0..20 {
+            stats.record(ms(33), ms(1));
+        }
+        assert!(stats.draw_ms() < 3.0, "mean should stay low");
+        assert!(
+            (stats.peak_draw_ms() - 20.0).abs() < 0.01,
+            "peak must still show the spike"
+        );
+    }
+
+    #[test]
+    fn the_window_forgets_old_frames() {
+        let mut stats = Stats::new();
+        for _ in 0..Stats::WINDOW {
+            stats.record(ms(100), ms(50));
+        }
+        for _ in 0..Stats::WINDOW {
+            stats.record(ms(10), ms(1));
+        }
+        assert!(
+            (stats.fps() - 100.0).abs() < 1.0,
+            "old slow frames should have rolled out, got {} fps",
+            stats.fps()
+        );
+        assert!((stats.peak_draw_ms() - 1.0).abs() < 0.01);
+    }
+}
+
+#[cfg(test)]
+mod fps_tests {
+    use super::*;
+
+    #[test]
+    fn stepping_walks_the_stops_and_saturates() {
+        assert_eq!(step_fps(30, true), 60);
+        assert_eq!(step_fps(30, false), 15);
+        assert_eq!(step_fps(240, true), 240, "must not run past the top stop");
+        assert_eq!(step_fps(5, false), 5, "must not run past the bottom stop");
+    }
+
+    #[test]
+    fn every_stop_stays_within_the_supported_range() {
+        let mut fps = 5;
+        for _ in 0..10 {
+            fps = step_fps(fps, true);
+            assert!(FPS_RANGE.contains(&fps), "{fps} escaped the range");
+        }
+    }
+
+    #[test]
+    fn the_budget_matches_the_requested_rate() {
+        assert_eq!(frame_budget(30).as_micros(), 33_333);
+        assert_eq!(frame_budget(60).as_micros(), 16_666);
+        // A zero budget would spin the loop; the range makes that unreachable.
+        assert!(frame_budget(*FPS_RANGE.end()) > StdDuration::ZERO);
+    }
+}

--- a/src/dsl/dsl.rs
+++ b/src/dsl/dsl.rs
@@ -327,8 +327,10 @@ fn register_default_compilers(effect_dsl: EffectDsl) -> EffectDsl {
             #[allow(deprecated)]
             fx::term256_colors().into()
         })
+        .register("breathe", compilers::breathe)
         .register("coalesce", compilers::coalesce)
         .register("coalesce_from", compilers::coalesce_from)
+        .register("color_wave", compilers::color_wave)
         .register("consume_tick", |_args| consume_tick().into())
         .register("delay", compilers::delay)
         .register("dissolve", |args| dissolve(args.effect_timer()?).into())
@@ -336,8 +338,13 @@ fn register_default_compilers(effect_dsl: EffectDsl) -> EffectDsl {
         .register("evolve", compilers::evolve)
         .register("evolve_into", compilers::evolve_into)
         .register("evolve_from", compilers::evolve_from)
+        .register("drift", compilers::drift)
         .register("expand", compilers::expand)
         .register("explode", compilers::explode)
+        .register("flicker", compilers::flicker)
+        .register("glow", compilers::glow)
+        .register("noise_field", compilers::noise_field)
+        .register("shimmer", compilers::shimmer)
         .register("fade_from", compilers::fade_from)
         .register("fade_from_fg", compilers::fade_from_fg)
         .register("fade_to", compilers::fade_to)
@@ -395,6 +402,54 @@ mod compilers {
         dsl::{dsl::Arguments, expressions::Expr, DslError},
         fx, Effect,
     };
+
+    pub(super) fn noise_field(args: &mut Arguments) -> Result<Effect, DslError> {
+        let from = args.color()?;
+        let to = args.color()?;
+        let scale = args.read_f32()?;
+        let speed = args.read_f32()?;
+        let octaves = args.read_u32()?;
+        fx::noise_field(from, to, scale, speed, octaves).into()
+    }
+
+    pub(super) fn color_wave(args: &mut Arguments) -> Result<Effect, DslError> {
+        let a = args.color()?;
+        let b = args.color()?;
+        let c = args.color()?;
+        let speed = args.read_f32()?;
+        let spread = args.read_f32()?;
+        fx::color_wave(a, b, c, speed, spread).into()
+    }
+
+    pub(super) fn glow(args: &mut Arguments) -> Result<Effect, DslError> {
+        let color = args.color()?;
+        let radius = args.read_f32()?;
+        let falloff = args.read_f32()?;
+        let period = args.read_f32()?;
+        fx::glow(color, radius, falloff, period).into()
+    }
+
+    pub(super) fn breathe(args: &mut Arguments) -> Result<Effect, DslError> {
+        fx::breathe(args.read_f32()?, args.read_f32()?).into()
+    }
+
+    pub(super) fn flicker(args: &mut Arguments) -> Result<Effect, DslError> {
+        fx::flicker(args.read_f32()?, args.read_f32()?).into()
+    }
+
+    pub(super) fn shimmer(args: &mut Arguments) -> Result<Effect, DslError> {
+        let intensity = args.read_f32()?;
+        let scale = args.read_f32()?;
+        let speed = args.read_f32()?;
+        fx::shimmer(intensity, scale, speed).into()
+    }
+
+    pub(super) fn drift(args: &mut Arguments) -> Result<Effect, DslError> {
+        let from = args.color()?;
+        let to = args.color()?;
+        let speed = args.read_f32()?;
+        fx::drift(from, to, speed).into()
+    }
 
     pub(super) fn coalesce(args: &mut Arguments) -> Result<Effect, DslError> {
         fx::coalesce(args.effect_timer()?).into()

--- a/src/fx/mod.rs
+++ b/src/fx/mod.rs
@@ -241,6 +241,7 @@ mod hsl_shift;
 mod lighten;
 mod never_complete;
 mod offscreen_buffer;
+mod organic;
 mod paint;
 mod ping_pong;
 mod prolong;
@@ -2343,6 +2344,177 @@ use crate::fx::{
     expand::Expand,
     explode::Explode,
 };
+
+// ── Ambient effects ──────────────────────────────────────────────────
+//
+// Unlike the transitions above, these never complete: they are meant to sit
+// under a UI for as long as it is open. Each sets the cell filter it can
+// actually act on -- painting effects take blank cells, modulating effects take
+// glyphs -- because applied to the wrong ones they run and do nothing at all.
+// An explicit `.with_filter()` still overrides the default.
+
+/// A slowly drifting fractal-noise field, painted as cell backgrounds.
+///
+/// The workhorse ambient background. Unlike a waveform-driven one it never
+/// visibly repeats: `scale` sets how tight the pattern is in cell space,
+/// `speed` how fast it drifts, `octaves` (1-4) how much fine detail is layered
+/// in.
+///
+/// `speed` is in noise units per second, and one noise unit spans `1/scale`
+/// cells — so at `scale = 0.2`, `speed = 1.0` moves the field five cells a
+/// second. Much below `0.5` and the drift stops reading as motion at all.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+/// use ratatui_core::style::Color;
+///
+/// fx::noise_field(Color::Black, Color::Blue, 0.2, 1.2, 3);
+/// ```
+#[must_use]
+pub fn noise_field(from: Color, to: Color, scale: f32, speed: f32, octaves: u32) -> Effect {
+    // Clamped on construction: octaves in particular is linear in cost and paid
+    // per cell per frame, so an unbounded value is a performance footgun.
+    organic::ambient(organic::Kind::NoiseField {
+        from,
+        to,
+        scale: scale.clamp(0.01, 2.0),
+        speed: speed.clamp(0.0, 5.0),
+        octaves: octaves.clamp(1, 4),
+    })
+}
+
+/// A three-stop colour gradient sweeping sideways, painted as cell backgrounds.
+///
+/// Periodic and directional, so it reads as a deliberate sweep where
+/// [`noise_field`] reads as drift. `spread` sets how much of the gradient is
+/// visible at once.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+/// use ratatui_core::style::Color;
+///
+/// fx::color_wave(Color::Red, Color::Green, Color::Blue, 1.2, 0.06);
+/// ```
+#[must_use]
+pub fn color_wave(a: Color, b: Color, c: Color, speed: f32, spread: f32) -> Effect {
+    organic::ambient(organic::Kind::ColorWave {
+        stops: [a, b, c],
+        speed: speed.clamp(0.0, 5.0),
+        spread: spread.clamp(0.005, 1.0),
+    })
+}
+
+/// A radial bloom centred on the area, breathing over `period` seconds.
+///
+/// `falloff` shapes the curve: 1.0 is linear, higher values keep the centre
+/// bright and drop off sharply at the edge. The radius is corrected for cell
+/// aspect ratio, so the bloom is round rather than a vertical ellipse.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+/// use ratatui_core::style::Color;
+///
+/// fx::glow(Color::Cyan, 20.0, 2.0, 3.0);
+/// ```
+#[must_use]
+pub fn glow(color: Color, radius: f32, falloff: f32, period: f32) -> Effect {
+    organic::ambient(organic::Kind::Glow {
+        color,
+        radius: radius.max(0.5),
+        falloff: falloff.clamp(0.1, 8.0),
+        period: period.max(0.1),
+    })
+}
+
+/// A slow brightness swell applied to whatever colour a cell already has.
+///
+/// Asymmetric on purpose — a slow rise and a quicker fall reads as breathing,
+/// where a sine reads as a machine. `intensity` is `0.0..=1.0`, `period` is in
+/// seconds.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+///
+/// fx::breathe(0.4, 3.0);
+/// ```
+#[must_use]
+pub fn breathe(intensity: f32, period: f32) -> Effect {
+    organic::ambient(organic::Kind::Breathe {
+        intensity: intensity.clamp(0.0, 1.0),
+        period: period.max(0.1),
+    })
+}
+
+/// Stochastic per-column brightness flicker, for a phosphor-tube feel.
+///
+/// Each column gets its own flicker path, so a line never pulses in unison.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+///
+/// fx::flicker(0.15, 2.0);
+/// ```
+#[must_use]
+pub fn flicker(intensity: f32, speed: f32) -> Effect {
+    organic::ambient(organic::Kind::Flicker {
+        intensity: intensity.clamp(0.0, 1.0),
+        speed: speed.clamp(0.0, 10.0),
+    })
+}
+
+/// A smooth noise-driven highlight sliding across the text.
+///
+/// Where [`flicker`] is stochastic per column and reads as electrical noise,
+/// this is spatial and continuous — a moving gradient. Centred so text
+/// brightens and dims around its true colour rather than only ever darkening.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+///
+/// fx::shimmer(0.4, 0.15, 0.8);
+/// ```
+#[must_use]
+pub fn shimmer(intensity: f32, scale: f32, speed: f32) -> Effect {
+    organic::ambient(organic::Kind::Shimmer {
+        intensity: intensity.clamp(0.0, 1.0),
+        scale: scale.clamp(0.01, 2.0),
+        speed: speed.clamp(0.0, 5.0),
+    })
+}
+
+/// A slow noise-driven wander of the foreground colour between two colours.
+///
+/// Uniform across the area — everything drifts together, unlike [`shimmer`],
+/// which varies per cell.
+///
+/// # Examples
+///
+/// ```
+/// use tachyonfx::fx;
+/// use ratatui_core::style::Color;
+///
+/// fx::drift(Color::Blue, Color::Magenta, 1.0);
+/// ```
+#[must_use]
+pub fn drift(from: Color, to: Color, speed: f32) -> Effect {
+    organic::ambient(organic::Kind::Drift {
+        from,
+        to,
+        speed: speed.clamp(0.0, 5.0),
+    })
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/fx/organic.rs
+++ b/src/fx/organic.rs
@@ -1,0 +1,473 @@
+//! Ambient effects: aperiodic, never-completing, meant to sit under a UI.
+//!
+//! Every other effect in this crate is a *transition* — it runs once against a
+//! timer and finishes. These are different in two ways that shape the design:
+//!
+//!   * **They never complete.** [`Shader::done`] is always `false` and there is
+//!     no timer, so [`Shader::execute`] accumulates its own elapsed time from
+//!     the tick duration. Driving them from a timer's alpha instead would mean
+//!     looping it, which restarts the field and leaves a visible seam once a
+//!     cycle.
+//!   * **They each know which cells they can act on.** An effect that paints an
+//!     absolute colour needs blank cells; one that modulates an existing colour
+//!     needs cells that carry a glyph. Applied to the wrong cells an effect
+//!     runs happily and does nothing at all — the failure mode is silence, so
+//!     the constructors set a default filter rather than leaving it to the
+//!     caller. An explicit `.with_filter()` still overrides it.
+
+use alloc::boxed::Box;
+
+use ratatui_core::{buffer::Buffer, layout::Rect, style::Color};
+
+use crate::{
+    CellFilter, ColorSpace, Duration, ToRgbComponents, cell_filter::FilterProcessor,
+    default_shader_impl, effect_timer::EffectTimer, math, noise, shader::Shader,
+};
+
+/// Which ambient effect an [`Ambient`] shader runs.
+///
+/// One shader type rather than seven keeps the elapsed-time bookkeeping in a
+/// single place, and keeps the whole thing `Clone` without boxing closures.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum Kind {
+    NoiseField {
+        from: Color,
+        to: Color,
+        scale: f32,
+        speed: f32,
+        octaves: u32,
+    },
+    ColorWave {
+        stops: [Color; 3],
+        speed: f32,
+        spread: f32,
+    },
+    Glow {
+        color: Color,
+        radius: f32,
+        falloff: f32,
+        period: f32,
+    },
+    Breathe {
+        intensity: f32,
+        period: f32,
+    },
+    Flicker {
+        intensity: f32,
+        speed: f32,
+    },
+    Shimmer {
+        intensity: f32,
+        scale: f32,
+        speed: f32,
+    },
+    Drift {
+        from: Color,
+        to: Color,
+        speed: f32,
+    },
+}
+
+impl Kind {
+    fn name(self) -> &'static str {
+        match self {
+            Kind::NoiseField { .. } => "noise_field",
+            Kind::ColorWave { .. } => "color_wave",
+            Kind::Glow { .. } => "glow",
+            Kind::Breathe { .. } => "breathe",
+            Kind::Flicker { .. } => "flicker",
+            Kind::Shimmer { .. } => "shimmer",
+            Kind::Drift { .. } => "drift",
+        }
+    }
+
+    /// The cells this effect can actually act on.
+    pub(super) fn default_filter(self) -> CellFilter {
+        match self {
+            // Paints an absolute colour: fills the blanks, leaves text legible.
+            //
+            // `Not(NonEmpty)`, not `Not(Text)`: `Text` matches the space
+            // character too, so `Not(Text)` selects neither blanks nor glyphs
+            // and the effect paints nothing at all.
+            Kind::NoiseField { .. } | Kind::ColorWave { .. } | Kind::Glow { .. } => {
+                CellFilter::Not(Box::new(CellFilter::NonEmpty))
+            },
+            // Modulates an existing colour: needs a glyph to act on.
+            Kind::Breathe { .. }
+            | Kind::Flicker { .. }
+            | Kind::Shimmer { .. }
+            | Kind::Drift { .. } => CellFilter::NonEmpty,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Ambient {
+    kind: Kind,
+    /// Seconds since the effect started. Monotonic and unbounded — the effects
+    /// here are all periodic in their own parameters, so it never needs wrapping.
+    elapsed: f32,
+    area: Option<Rect>,
+    color_space: ColorSpace,
+    cell_filter: Option<FilterProcessor>,
+}
+
+/// Builds an ambient effect, pre-filtered to the cells its kind can act on.
+pub(super) fn ambient(kind: Kind) -> crate::Effect {
+    use crate::IntoEffect;
+    let filter = kind.default_filter();
+    Ambient::new(kind).into_effect().with_filter(filter)
+}
+
+impl Ambient {
+    fn new(kind: Kind) -> Self {
+        Self {
+            kind,
+            elapsed: 0.0,
+            area: None,
+            color_space: ColorSpace::Rgb,
+            cell_filter: None,
+        }
+    }
+}
+
+fn lerp_rgb(from: Color, to: Color, t: f32) -> Color {
+    let (ar, ag, ab) = from.to_rgb();
+    let (br, bg, bb) = to.to_rgb();
+    let t = t.clamp(0.0, 1.0);
+    let mix = |a: u8, b: u8| math::round(a as f32 + (b as f32 - a as f32) * t) as u8;
+    Color::Rgb(mix(ar, br), mix(ag, bg), mix(ab, bb))
+}
+
+/// Scales a colour's brightness. Above 1.0 moves towards white, below towards
+/// black; 1.0 leaves it untouched.
+fn scale_brightness(color: Color, factor: f32) -> Color {
+    if factor >= 1.0 {
+        lerp_rgb(color, Color::Rgb(255, 255, 255), (factor - 1.0).min(1.0))
+    } else {
+        lerp_rgb(color, Color::Rgb(0, 0, 0), 1.0 - factor)
+    }
+}
+
+impl Shader for Ambient {
+    default_shader_impl!(area, filter, color_space, clone);
+
+    fn name(&self) -> &'static str {
+        self.kind.name()
+    }
+
+    /// Ambient effects never finish; the caller decides when to stop rendering
+    /// them.
+    fn done(&self) -> bool {
+        false
+    }
+
+    fn timer(&self) -> Option<EffectTimer> {
+        None
+    }
+
+    fn timer_mut(&mut self) -> Option<&mut EffectTimer> {
+        None
+    }
+
+    fn execute(&mut self, duration: Duration, area: Rect, buf: &mut Buffer) {
+        self.elapsed += duration.as_secs_f32();
+
+        let kind = self.kind;
+        let time = self.elapsed;
+        let cell_iter = self.cell_iter(buf, area);
+
+        match kind {
+            Kind::NoiseField {
+                from,
+                to,
+                scale,
+                speed,
+                octaves,
+            } => cell_iter.for_each_cell(move |pos, cell| {
+                let t = noise::fbm2(
+                    pos.x as f32 * scale,
+                    pos.y as f32 * scale + time * speed,
+                    octaves,
+                );
+                cell.set_bg(lerp_rgb(from, to, t));
+            }),
+
+            Kind::ColorWave {
+                stops,
+                speed,
+                spread,
+            } => cell_iter.for_each_cell(move |pos, cell| {
+                let n = stops.len() as f32;
+                let phase = math::rem_euclid(pos.x as f32 * spread + time * speed, n);
+                let index = math::floor(phase) as usize % stops.len();
+                let next = (index + 1) % stops.len();
+                let frac = phase - math::floor(phase);
+                cell.set_bg(lerp_rgb(stops[index], stops[next], frac));
+            }),
+
+            Kind::Glow {
+                color,
+                radius,
+                falloff,
+                period,
+            } => {
+                let cx = area.x as f32 + area.width as f32 / 2.0;
+                let cy = area.y as f32 + area.height as f32 / 2.0;
+                let swell = noise::breathe(time / period);
+
+                cell_iter.for_each_cell(move |pos, cell| {
+                    let dx = pos.x as f32 - cx;
+                    // Terminal cells are roughly twice as tall as they are
+                    // wide, so an unscaled radius draws a vertical ellipse.
+                    let dy = (pos.y as f32 - cy) * 2.0;
+                    let distance = math::sqrt(dx * dx + dy * dy);
+                    let intensity =
+                        (1.0 - math::powf(distance / radius, falloff)).clamp(0.0, 1.0);
+                    cell.set_bg(lerp_rgb(cell.bg, color, intensity * swell));
+                });
+            },
+
+            Kind::Breathe { intensity, period } => {
+                // Map the 0..1 curve onto 1-intensity ..= 1.
+                let factor = 1.0 - intensity * (1.0 - noise::breathe(time / period));
+                cell_iter.for_each_cell(move |_, cell| {
+                    cell.set_fg(scale_brightness(cell.fg, factor));
+                });
+            },
+
+            Kind::Flicker { intensity, speed } => {
+                cell_iter.for_each_cell(move |pos, cell| {
+                    let factor = noise::flicker(time * speed, pos.x as f32 * 17.31, intensity);
+                    cell.set_fg(scale_brightness(cell.fg, factor));
+                });
+            },
+
+            Kind::Shimmer {
+                intensity,
+                scale,
+                speed,
+            } => cell_iter.for_each_cell(move |pos, cell| {
+                let n = noise::fbm2(pos.x as f32 * scale, time * speed + pos.y as f32 * 0.5, 2);
+                // Centred on 1.0 so text brightens and dims around its true
+                // colour rather than only ever getting darker.
+                let factor = 1.0 + intensity * (n - 0.5);
+                cell.set_fg(scale_brightness(cell.fg, factor));
+            }),
+
+            Kind::Drift { from, to, speed } => {
+                let t = noise::noise1(time * speed);
+                let color = lerp_rgb(from, to, t);
+                cell_iter.for_each_cell(move |_, cell| {
+                    cell.set_fg(color);
+                });
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::{buffer::Buffer, layout::Rect, style::Color};
+
+    use crate::{CellFilter, Duration, fx};
+
+    fn area() -> Rect {
+        Rect::new(0, 0, 12, 4)
+    }
+
+    /// A buffer with one line of text and three blank ones, so both families of
+    /// effect have something to act on.
+    fn buffer() -> Buffer {
+        let mut buf = Buffer::empty(area());
+        buf.set_string(0, 1, "hello world", ratatui_core::style::Style::default());
+        buf
+    }
+
+    fn painting() -> [crate::Effect; 3] {
+        [
+            fx::noise_field(Color::Black, Color::Blue, 0.2, 0.05, 3),
+            fx::color_wave(Color::Red, Color::Green, Color::Blue, 0.6, 0.06),
+            fx::glow(Color::Cyan, 8.0, 2.0, 3.0),
+        ]
+    }
+
+    fn modulating() -> [crate::Effect; 4] {
+        [
+            fx::breathe(0.5, 3.0),
+            fx::flicker(0.4, 2.0),
+            fx::shimmer(0.5, 0.15, 0.8),
+            fx::drift(Color::Blue, Color::Magenta, 0.35),
+        ]
+    }
+
+    /// The defining property: these are meant to sit under a UI indefinitely,
+    /// so nothing should ever mark them finished.
+    #[test]
+    fn ambient_effects_never_complete() {
+        for mut effect in painting().into_iter().chain(modulating()) {
+            let mut buf = buffer();
+            for _ in 0..100 {
+                effect.process(Duration::from_millis(100), &mut buf, area());
+            }
+            assert!(
+                !effect.done() && effect.running(),
+                "{} should still be running after 10s",
+                effect.name()
+            );
+        }
+    }
+
+    /// Applied to the wrong cells an effect runs and does nothing at all, with
+    /// no error anywhere -- so the constructors pick the filter, and that choice
+    /// is worth asserting.
+    #[test]
+    fn constructors_target_the_cells_they_can_act_on() {
+        for effect in painting() {
+            assert!(
+                matches!(effect.cell_filter(), Some(CellFilter::Not(inner)) if **inner == CellFilter::NonEmpty),
+                "{} paints, so it must target blank cells",
+                effect.name()
+            );
+        }
+        for effect in modulating() {
+            assert!(
+                matches!(effect.cell_filter(), Some(CellFilter::NonEmpty)),
+                "{} modulates, so it must target glyph cells",
+                effect.name()
+            );
+        }
+    }
+
+    #[test]
+    fn painting_effects_fill_blanks_and_leave_text_alone() {
+        for mut effect in painting() {
+            let before = buffer();
+            let mut after = buffer();
+            effect.process(Duration::from_millis(500), &mut after, area());
+
+            assert_ne!(
+                before[(0, 0)].bg,
+                after[(0, 0)].bg,
+                "{} should have painted the blank row",
+                effect.name()
+            );
+            assert_eq!(
+                before[(0, 1)].symbol(),
+                after[(0, 1)].symbol(),
+                "{} must not disturb glyphs",
+                effect.name()
+            );
+        }
+    }
+
+    #[test]
+    fn modulating_effects_reach_text() {
+        for mut effect in modulating() {
+            let before = buffer();
+            let mut after = buffer();
+            // Two ticks: some of these start at a neutral point.
+            effect.process(Duration::from_millis(600), &mut after, area());
+            effect.process(Duration::from_millis(600), &mut after, area());
+
+            assert_ne!(
+                before[(0, 1)].fg,
+                after[(0, 1)].fg,
+                "{} should have modulated the text row",
+                effect.name()
+            );
+        }
+    }
+
+    /// The failure this catches: an effect that compiles, paints, and reports
+    /// itself as running, while being visually static. `noise_field` shipped
+    /// that way -- its documented speed was so low the field drifted about one
+    /// RGB unit per second, which reads as a still image.
+    ///
+    /// Measured at the parameters used in each constructor's doc example, so
+    /// the thing being pinned is what a user actually copies.
+    #[test]
+    fn every_effect_produces_visible_motion() {
+        /// Mean absolute RGB change per channel per cell over one second.
+        /// Around 1 is imperceptible; 10 is a clear but gentle drift.
+        const MIN_DELTA: f32 = 8.0;
+
+        let cases: [(crate::Effect, u16, bool); 7] = [
+            (fx::noise_field(Color::Rgb(10, 12, 30), Color::Rgb(110, 60, 160), 0.2, 1.2, 3), 2, false),
+            (fx::color_wave(Color::Red, Color::Green, Color::Blue, 1.2, 0.06), 2, false),
+            (fx::glow(Color::Cyan, 20.0, 2.0, 3.0), 2, false),
+            (fx::breathe(0.4, 3.0), 5, true),
+            (fx::flicker(0.15, 2.0), 5, true),
+            (fx::shimmer(0.4, 0.15, 0.8), 5, true),
+            (fx::drift(Color::Blue, Color::Magenta, 1.0), 5, true),
+        ];
+
+        for (mut effect, row, foreground) in cases {
+            let name = effect.name();
+            let area = Rect::new(0, 0, 40, 8);
+            let mut buf = Buffer::empty(area);
+            buf.set_string(
+                0,
+                5,
+                "abcdefghij".repeat(4).as_str(),
+                ratatui_core::style::Style::default().fg(Color::Rgb(150, 190, 220)),
+            );
+
+            let sample = |b: &Buffer| -> alloc::vec::Vec<(i32, i32, i32)> {
+                (0..40)
+                    .map(|x| {
+                        let c = if foreground { b[(x, row)].fg } else { b[(x, row)].bg };
+                        match c {
+                            Color::Rgb(r, g, bl) => (i32::from(r), i32::from(g), i32::from(bl)),
+                            _ => (0, 0, 0),
+                        }
+                    })
+                    .collect()
+            };
+
+            effect.process(Duration::from_millis(33), &mut buf, area);
+            let before = sample(&buf);
+            for _ in 0..30 {
+                effect.process(Duration::from_millis(33), &mut buf, area);
+            }
+            let after = sample(&buf);
+
+            let total: i32 = before
+                .iter()
+                .zip(&after)
+                .map(|(a, b)| (a.0 - b.0).abs() + (a.1 - b.1).abs() + (a.2 - b.2).abs())
+                .sum();
+            let delta = total as f32 / (40.0 * 3.0);
+
+            assert!(
+                delta >= MIN_DELTA,
+                "{name} moved {delta:.2} per channel in 1s, below the {MIN_DELTA} \
+                 visibility floor -- it will look static"
+            );
+        }
+    }
+
+    /// Every constructor is reachable from a default DSL, which is what lets an
+    /// application expose them as configuration rather than code.
+    #[cfg(feature = "dsl")]
+    #[test]
+    fn effects_compile_from_the_default_dsl() {
+        for source in [
+            "fx::noise_field(Color::Black, Color::Blue, 0.2, 0.05, 3)",
+            "fx::color_wave(Color::Red, Color::Green, Color::Blue, 0.6, 0.06)",
+            "fx::glow(Color::Cyan, 20.0, 2.0, 3.0)",
+            "fx::breathe(0.4, 3.0)",
+            "fx::flicker(0.15, 2.0)",
+            "fx::shimmer(0.4, 0.15, 0.8)",
+            "fx::drift(Color::Blue, Color::Magenta, 0.35)",
+        ] {
+            let dsl = crate::dsl::EffectDsl::new();
+            assert!(
+                dsl.compiler().compile(source).is_ok(),
+                "should compile: {source}"
+            );
+        }
+    }
+}
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod interpolation;
 mod lru_cache;
 mod math;
 mod motion;
+pub mod noise;
 /// Spatial patterns for controlling effect progression.
 pub mod pattern;
 mod rect_ext;

--- a/src/math.rs
+++ b/src/math.rs
@@ -47,6 +47,16 @@ pub fn wave_cos(t: f32) -> f32 {
     wave_sin(t + 0.25)
 }
 
+/// Euclidean remainder, for wrapping a value into `0.0..m`.
+///
+/// `f32::rem_euclid` is std-only, so this is expressed with the crate's own
+/// `floor` to behave identically in both environments.
+#[inline(always)]
+#[must_use]
+pub(crate) fn rem_euclid(x: f32, m: f32) -> f32 {
+    x - m * floor(x / m)
+}
+
 /// Square root function using micromath (faster than std)
 #[inline]
 pub(crate) fn sqrt(x: f32) -> f32 {

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,0 +1,218 @@
+//! Value noise and fractal Brownian motion.
+//!
+//! [`crate::wave`] provides periodic waveforms; this module provides aperiodic
+//! ones. The distinction matters for ambient effects: a background driven by a
+//! sine visibly repeats, and the eye picks the period out quickly. Noise does
+//! not repeat, which is what makes an effect read as organic.
+//!
+//! Everything here is deterministic pseudo-noise seeded by position, not
+//! randomness. The same coordinates always yield the same value, so a field is
+//! reproducible, testable, and stable as the terminal is resized.
+//!
+//! ```
+//! use tachyonfx::noise;
+//!
+//! // A value in 0.0..=1.0 for any point in the plane.
+//! let v = noise::fbm2(3.5, 1.25, 3);
+//! assert!((0.0..=1.0).contains(&v));
+//! ```
+
+use crate::math;
+
+/// Robert Jenkins' 32-bit integer hash, mapped to `0.0..=1.0`.
+///
+/// Wrapping arithmetic throughout: this is a bit-mixing function, so overflow
+/// is the mechanism rather than an error.
+fn hash_noise(n: i64) -> f32 {
+    let mut n = (n as u64 as u32).wrapping_add(0x1656_67b1);
+    n = (n ^ (n >> 16)).wrapping_mul(0x045d_9f3b);
+    n = (n ^ (n >> 16)).wrapping_mul(0x045d_9f3b);
+    n ^= n >> 16;
+    (n >> 16) as f32 / u16::MAX as f32
+}
+
+/// Hermite smoothstep, easing interpolation between lattice points so the field
+/// has no visible grid.
+fn smooth(t: f32) -> f32 {
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// 1D value noise in `0.0..=1.0`.
+#[must_use]
+pub fn noise1(x: f32) -> f32 {
+    let xi = math::floor(x) as i64;
+    let xf = x - xi as f32;
+    let a = hash_noise(xi);
+    let b = hash_noise(xi + 1);
+    a + smooth(xf) * (b - a)
+}
+
+/// 2D value noise in `0.0..=1.0`.
+#[must_use]
+pub fn noise2(x: f32, y: f32) -> f32 {
+    // Prime stride keeps rows from hashing into each other.
+    const STRIDE: i64 = 7919;
+
+    let (xi, yi) = (math::floor(x) as i64, math::floor(y) as i64);
+    let (xf, yf) = (x - xi as f32, y - yi as f32);
+
+    let a = hash_noise(xi + yi * STRIDE);
+    let b = hash_noise(xi + 1 + yi * STRIDE);
+    let c = hash_noise(xi + (yi + 1) * STRIDE);
+    let d = hash_noise(xi + 1 + (yi + 1) * STRIDE);
+
+    let (u, v) = (smooth(xf), smooth(yf));
+    let top = a + u * (b - a);
+    let bot = c + u * (d - c);
+    top + v * (bot - top)
+}
+
+/// Fractal Brownian motion: layered noise at rising frequency and falling
+/// amplitude, in `0.0..=1.0`.
+///
+/// More octaves means more fine detail, and linearly more work — which for a
+/// per-cell effect is paid every cell, every frame. Three is usually plenty.
+///
+/// Returns the neutral midpoint for a zero octave count, so a degenerate
+/// parameter yields a flat field rather than a panic.
+#[must_use]
+pub fn fbm2(x: f32, y: f32, octaves: u32) -> f32 {
+    const LACUNARITY: f32 = 2.0;
+    const GAIN: f32 = 0.5;
+
+    if octaves == 0 {
+        return 0.5;
+    }
+
+    let mut value = 0.0;
+    let mut amplitude = 1.0;
+    let mut frequency = 1.0;
+    let mut total = 0.0;
+
+    for _ in 0..octaves {
+        value += amplitude * noise2(x * frequency, y * frequency);
+        total += amplitude;
+        amplitude *= GAIN;
+        frequency *= LACUNARITY;
+    }
+
+    value / total
+}
+
+/// Asymmetric breathing curve over one unit of `t`, in `0.0..=1.0`.
+///
+/// A slow cubic rise over the first 60%, then a quicker quadratic fall.
+/// Deliberately not a sine: the asymmetry is what makes it read as breathing
+/// rather than oscillating.
+#[must_use]
+pub fn breathe(t: f32) -> f32 {
+    let t = math::rem_euclid(t, 1.0);
+    if t < 0.6 {
+        let p = t / 0.6;
+        p * p * p
+    } else {
+        let p = (t - 0.6) / 0.4;
+        1.0 - p * p
+    }
+}
+
+/// Stochastic brightness factor in `1-intensity ..= 1`, for a phosphor-style
+/// flicker.
+///
+/// Squared to bias towards bright, so it reads as occasional dips rather than
+/// constant noise. Distinct `seed` values give independent flicker paths.
+#[must_use]
+pub fn flicker(t: f32, seed: f32, intensity: f32) -> f32 {
+    let n = noise2(t, seed);
+    1.0 - intensity * n * n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noise_is_bounded_and_deterministic() {
+        for i in 0..200 {
+            let (x, y) = (i as f32 * 0.37, i as f32 * 0.11);
+            let v = noise2(x, y);
+            assert!((0.0..=1.0).contains(&v), "noise2({x}, {y}) = {v}");
+            assert_eq!(v, noise2(x, y), "noise must be deterministic");
+
+            let v = noise1(x);
+            assert!((0.0..=1.0).contains(&v), "noise1({x}) = {v}");
+        }
+    }
+
+    #[test]
+    fn noise_is_continuous() {
+        // Neighbouring samples must not jump: a discontinuous field looks like
+        // static rather than a smooth gradient.
+        let mut previous = noise2(0.0, 0.0);
+        for i in 1..500 {
+            let v = noise2(i as f32 * 0.01, 0.0);
+            assert!(
+                (v - previous).abs() < 0.2,
+                "discontinuity at step {i}: {previous} -> {v}"
+            );
+            previous = v;
+        }
+    }
+
+    #[test]
+    fn noise_actually_varies() {
+        // A constant field would satisfy the bounds and continuity checks above
+        // while being useless.
+        let samples: alloc::vec::Vec<f32> =
+            (0..100).map(|i| noise2(i as f32 * 0.7, 3.0)).collect();
+        let min = samples.iter().copied().fold(f32::MAX, f32::min);
+        let max = samples.iter().copied().fold(f32::MIN, f32::max);
+        assert!(max - min > 0.3, "field is too flat: {min}..{max}");
+    }
+
+    #[test]
+    fn fbm_is_bounded_and_handles_zero_octaves() {
+        assert_eq!(fbm2(1.0, 2.0, 0), 0.5);
+        for octaves in 1..=5 {
+            for i in 0..100 {
+                let v = fbm2(i as f32 * 0.3, i as f32 * 0.2, octaves);
+                assert!((0.0..=1.0).contains(&v), "fbm2 out of range: {v}");
+            }
+        }
+    }
+
+    #[test]
+    fn breathe_rises_then_falls_and_stays_bounded() {
+        assert_eq!(breathe(0.0), 0.0);
+        assert!((breathe(0.6) - 1.0).abs() < 1e-6, "peak should be at 0.6");
+        assert!(breathe(0.3) < breathe(0.5), "should rise before the peak");
+        assert!(breathe(0.8) < breathe(0.7), "should fall after the peak");
+
+        for i in 0..=100 {
+            let v = breathe(i as f32 / 100.0);
+            assert!((0.0..=1.0).contains(&v), "breathe out of range: {v}");
+        }
+    }
+
+    #[test]
+    fn breathe_is_periodic() {
+        for i in 0..50 {
+            let t = i as f32 / 50.0;
+            assert!(
+                (breathe(t) - breathe(t + 3.0)).abs() < 1e-5,
+                "breathe must repeat every unit"
+            );
+        }
+    }
+
+    #[test]
+    fn flicker_stays_within_its_intensity_band() {
+        for i in 0..200 {
+            let v = flicker(i as f32 * 0.05, 1.0, 0.3);
+            assert!((0.7..=1.0).contains(&v), "flicker escaped its band: {v}");
+        }
+        // Zero intensity must be a true no-op, so the effect can be disabled by
+        // parameter without a special case.
+        assert_eq!(flicker(1.23, 4.0, 0.0), 1.0);
+    }
+}


### PR DESCRIPTION
Implements what I described in #96. Opening it as a concrete proposal rather
than a finished thing.

## What's here

**`pub mod noise`** — value noise, fbm, and two shaping curves. Deterministic
pseudo-noise seeded by position, sitting next to `wave` as its aperiodic
counterpart. Independent of everything below; useful on its own.

**Seven effects.** Three that paint cell backgrounds (`noise_field`,
`color_wave`, `glow`) and four that modulate existing colours (`breathe`,
`flicker`, `shimmer`, `drift`). All registered with the default DSL.

**An example** (`cargo run -p organic-effects`) cycling through them on generic
content, each compiled from its DSL expression rather than constructed in Rust.

The three commits are independent in that order — `noise` can be taken alone if
the ambient question needs more discussion.

## The design decisions worth arguing about

The code takes a position but I'm not attached to any of them.

**Never-completing effects.** `done()` is always `false`, `timer()` returns
`None`, and `execute` accumulates its own elapsed time from the tick duration.
`EffectTimer` simply doesn't apply. Wrapping a transition in `fx::repeating`
isn't an alternative: looping restarts the field and leaves a visible seam once
a cycle.

**Constructors set a default cell filter.** A departure from the rest of `fx::`,
which leaves the filter unset. These can't: a painting effect restricted to
glyphs, or a modulating one restricted to blanks, runs, reports itself as
running, and does nothing whatsoever. The failure mode is silence, so the
constructor chooses. `with_filter` still overrides.

**One `Ambient` shader with a `Kind` enum** rather than seven structs — keeps
the elapsed-time bookkeeping in one place and stays `Clone` without boxing
closures. Seven files would match the existing layout better; happy to switch.

## Notes for reviewers

`Not(NonEmpty)` is the filter for blank cells, **not** `Not(Text)` — `Text`
matches the space character, so `Not(Text)` selects neither blanks nor glyphs.
This is the first of the two gotchas I mentioned in #96 and it cost me a while
to find.

`math::rem_euclid` is added because `f32::rem_euclid` is std-only and this has
to build under `no_std`.

## Testing

Full CI matrix locally, including `--no-default-features`. Clippy adds no new
warnings over the 3 already on `development`.

Beyond the usual, the tests pin two things specific to ambient effects:

- **that each effect is actually visible** — measured as mean RGB change per
  channel per second, at the parameters used in each doc example. This caught a
  real bug: `noise_field` originally shipped with a documented `speed` so low it
  drifted about one RGB unit per second, which compiles, paints, reports itself
  as running, and looks like a still image.
- **that each targets cells it can act on**, for the reason above.

---

*Written with AI assistance.*